### PR TITLE
pages: use blockquotes for quotations

### DIFF
--- a/pages/mentor/01-why_gsoc_matters.md
+++ b/pages/mentor/01-why_gsoc_matters.md
@@ -8,36 +8,34 @@ sidebar: mentor_sidebar
 
 In addition to the great code produced, the GSoC experience is about building open source communities. By focusing on students, we are going to the source of all future open source efforts. The ultimate success of the GSoC program is thus measured by the quality of the student experience. Each organization and each mentor plays a crucial role in creating this experience through their project ideas, developer culture, and the guidance they provide. They are rewarded by new code and by adding skilled new developers to their ranks. But don't take our word for it! Heres what some of the students had to say:
 
-"Overall, this is the most productive summer I ever had. It increased my confidence as a developer and as a person that I can actually pull off a project like this and interact with awesome people like you. I also become a part of a growing community and hope to help it grow further."
+> Overall, this is the most productive summer I ever had. It increased my confidence as a developer and as a person that I can actually pull off a project like this and interact with awesome people like you. I also become a part of a growing community and hope to help it grow further.
+> 
+> *—Chetan Bansal*
 
-*Chetan Bansal*
+> There aren't many opportunities for computational biology enthusiasts to make a difference in the field while still in school. GSOC at [my org] was one such gem of an opportunity that illustrated exactly why writing software for biological research is benefited by a background in biology. The experience I have gained here is definitely irreplaceable. The fundamentals of open-source programming and the rhythm associated with regular coding and problem solving helped nourish an intellectual side of me that I will not forget in a hurry. This is definitely not the last time you will see me.
+> 
+> *—Chinmoy Bhatiya*
 
-"There aren't many opportunities for computational biology enthusiasts to make a difference in the field while still in school. GSOC at [my org] was one such gem of an opportunity that illustrated exactly why writing software for biological research is benefited by a background in biology. The experience I have gained here is definitely irreplaceable. The fundamentals of open-source programming and the rhythm associated with regular coding and problem solving helped nourish an intellectual side of me that I will not forget in a hurry. This is definitely not the last time you will see me."
+> This was the first time I took part into either GSoC or an Open Source project, and it was also one of the most exciting things I've ever done! This project gave me the chance to spend ~3 months learning lot of new things, having fun, doing something for the community and even getting pay for that! That's an amazing combination! --I will remain as an active participant of [my org's] community beyond the official end of GSoC 2009!
+> 
+> *—Gerardo Huck*
 
-*Chinmoy Bhatiya*
+> It was definitely a very good learning experience for me. --But I have some unfinished works-- So I'll continue this project after GSoC, and be help to drive [my org's] development.
+> 
+> *—Kozo Nishida*
 
-"This was the first time I took part into either GSoC or an Open Source project, and it was also one of the most exciting things I've ever done! This project gave me the chance to spend ~3 months learning lot of new things, having fun, doing something for the community and even getting pay for that! That's an amazing combination! --I will remain as an active participant of [my org's] community beyond the official end of GSoC 2009!"
+> It was the first time that I worked with an open source community and it was really a great experience. I am very thankful to Google and [my org] for providing me this great opportunity. I would like to thank [my mentors] for their excellent support during the summer. Looking forward to working with you again.
+> 
+> *—Srinivasarao Vundavalli*
 
-*Gerardo Huck*
+> Get over yourself. Understand there are people smarter than you or people better at some things than you. Just the same, you're still needed. JFDI (Just Fabulously Do It) and find your niche.
+> 
+> *—Justin Hunter*
 
-"It was definitely a very good learning experience for me. --But I have some unfinished works-- So I'll continue this project after GSoC, and be help to drive [my org's] development."
+> This year's GSoC was my first contribution to the open source world and I will like to continue my contributions to open source whenever I get the opportunity. The best thing about open source is the huge opportunity it provides to everyone who wants to explore their career in the technical world and develop in their field of interest. The way people from different streams come together, exploit their talents, cooperate, coordinate, focus their collective efforts towards a common goal that will help many more people in the end is the best part about open source.
+> 
+> *—Kanika Vats*
 
-*Kozo Nishida*
-
-"It was the first time that I worked with an open source community and it was really a great experience. I am very thankful to Google and [my org] for providing me this great opportunity. I would like to thank [my mentors] for their excellent support during the summer. Looking forward to working with you again."
-
-*Srinivasarao Vundavalli*
-
-"Get over yourself. Understand there are people smarter than you or people better at some things than you. Just the same, you're still needed. JFDI (Just Fabulously Do It) and find your niche."
-
-*Justin Hunter*
-
-"This year's GSoC was my first contribution to the open source world and I will like to continue my contributions to open source whenever I get the opportunity. The best thing about open source is the huge opportunity it provides to everyone who wants to explore their career in the technical world and develop in their field of interest. The way people from different streams come together, exploit their talents, cooperate, coordinate, focus their collective efforts towards a common goal that will help many more people in the end is the best part about open source."
-
-*Kanika Vats*
-
-"So, we've now gotten to the end of it all. It does feel a bit sad, I really did have a great time coding this summer and hopefully I can do it again. I don't think I've ever learned this much in a summer job and everybody working with me have been really fantastic."
-
-*Anna Granudd*
-
-
+> So, we've now gotten to the end of it all. It does feel a bit sad, I really did have a great time coding this summer and hopefully I can do it again. I don't think I've ever learned this much in a summer job and everybody working with me have been really fantastic.
+> 
+> *—Anna Granudd*


### PR DESCRIPTION
This should better visually connect the quote with the speaker.  Previously with such a long list of quotes, it could get a little confusing whether the name went with the preceding or following quote.  Also use em dashes for attributing the speaker.