### PR TITLE
Fix make build-image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update
 
 RUN apt-get install -y \
     nodejs \
-    python-pygments
+    python3-pygments
 
 RUN apt-get clean \
   && rm -rf /var/lib/apt/lists/


### PR DESCRIPTION
Need to update to `python3-pygments`, currently you get the following error when running `make build-image`:

```
 => ERROR [ 4/10] RUN apt-get install -y     nodejs     python-pygments                                                                                 1.0s
------
 > [ 4/10] RUN apt-get install -y     nodejs     python-pygments:
#7 0.228 Reading package lists...
#7 0.738 Building dependency tree...
#7 0.861 Reading state information...
#7 0.883 Package python-pygments is not available, but is referred to by another package.
#7 0.883 This may mean that the package is missing, has been obsoleted, or
#7 0.883 is only available from another source
#7 0.883 However the following packages replace it:
#7 0.883   python3-pygments
#7 0.883 
#7 0.961 E: Package 'python-pygments' has no installation candidate
```