### PR TITLE
docs: Fix Markdown Lint Errors in Communication Best Practices Guide

### DIFF
--- a/pages/student/11-communication_best_practices.md
+++ b/pages/student/11-communication_best_practices.md
@@ -9,15 +9,17 @@ sidebar: student_sidebar
 One of the best things about GSoC is the group of individuals from diverse cultures and different open source organizations that participate each year. This also means that you cannot make any assumptions about communication. Specifically:
 
 Issues we see interested contributors do that will irritate your mentors and community very quickly (and likely result in you not being accepted into the org):
-* Never address a person with a gendered title (Sir, Mam, etc. unless the person has indicated that a certain title is acceptable). The best thing to do is just say 'Mentors', especially during the application period of the program when you may not know mentor's specific displaynames yet. 
+
+* Never address a person with a gendered title (Sir, Mam, etc. unless the person has indicated that a certain title is acceptable). The best thing to do is just say 'Mentors', especially during the application period of the program when you may not know mentor's specific displaynames yet.
 * Never assume a person's gender based on display name, profile pic, etc.
 * Never reach out to mentors during the application period via social media like LinkedIn, etc. to get them to answer your questions if they haven't responded in a couple of days.
 * Don't expect instant answers. Remember you are working with volunteers.
 * One of the best ways to destroy your reputation early is to repeatedly ask questions on the chat channel or the mailing list that are covered in a FAQ or other types of documentation.
 
 Remember...
+
 * Respect the mentors, org admin, other GSoC applicants and the org's community members. Respect everyone equally regardless of their gender.
-* Always read the [Program Rules](https://developers.google.com/open-source/gsoc/rules), [FAQ](https://developers.google.com/open-source/gsoc/faq) and this guide first!
+* Always read the [Program Rules](https://developers.google.com/open-source/gsoc/rules), [FAQ](https://developers.google.com/open-source/gsoc/faq) and this guide first！
 * Avoid humor when communicating with the entire GSoC community. It does not translate well to large groups and is likely to be misconstrued by someone.
 * Remember that other peoples' time is just as valuable as your own.
 


### PR DESCRIPTION
This PR addresses the Markdown linting errors reported by the CI/CD pipeline for the `11-communication_best_practices.md` document within the GSoC Guides repository. The reported issues were primarily related to trailing spaces and the formatting of lists, which could potentially hinder proper rendering on the website. Here are the specific changes made:

- Removed trailing spaces that violated MD009/no-trailing-spaces rule.
- Ensured that lists are surrounded by blank lines, correcting the MD032/blanks-around-lists errors.

By resolving these linting issues, this PR aims to improve the readability and maintainability of the Communication Best Practices guide, ensuring that it adheres to the Markdown standards expected by our documentation pipeline.

Link to the CI/CD error report: [CI Error Report](https://github.com/google/gsocguides/actions/runs/8430774430/job/23087157241)

These changes were made in response to the CI/CD process identifying formatting inconsistencies that could affect the presentation of the document. Ensuring that our documentation meets these standards is crucial for maintaining a high-quality guide for GSoC participants.
