### PR TITLE
Add section on ranking similar proposals

### DIFF
--- a/pages/mentor/19-selecting_students_and_mentors.md
+++ b/pages/mentor/19-selecting_students_and_mentors.md
@@ -32,6 +32,10 @@ If you ask for a certain number of slots and are given that number but then real
 
 You can not substitute in other proposals after you have ranked your proposals and received the slot allocations.
 
+## Multiple contributors submitting proposals on the same idea
+
+Based on an organization's list of ideas, multiple contributors might submit proposals based on the same idea. Given that the project of one GSoC contributor should not depend on the project of another GSoC contributor, you should only select one proposal per project: the ranking list of an organization should rank stand-alone projects, not potential contributors for the same project. In case the specific proposal is not matched (e.g., contributor selected by multiple orgs - next section), Google will contact you to see which project you would like to replace that slot with.
+
 ## GSoC contributors selected by multiple orgs
 
 GSoC contributors are allowed to submit up to 3 proposals each year, and they can be to multiple organizations. When organizations have chosen their desired GSoC contributors based on their ranked slot allocations, it is inevitably the case that a few GSoC contributors are sought by more than one organization (usually around 10-20 each year).


### PR DESCRIPTION
As a first-time org admin, it was not clear to me what ranking actually means when multiple contributors submit proposals based on the same idea.

Reading between the lines in various pages, I understand that I should select only one proposal per independent project idea, and that if we don't get a student, we will be offered another one.

Could someone please confirm?

## Example

If I have the following unsorted list:

- Student 1, idea A
- Student 2, idea B
- Student 3, idea A
- Student 4, idea C
- Student 5, idea B

my ranking list should look like:

1. Student 3, idea A (best of A)
2. Student 2, idea B (best of B)
3. Student 4, idea C

leaving all other proposals outside the ranking list, and assuming that all the ranked proposals are of high quality.