### PR TITLE
Fix outdated external links in guides

### DIFF
--- a/pages/mentor/09-open_source_culture.md
+++ b/pages/mentor/09-open_source_culture.md
@@ -37,7 +37,7 @@ People come up with abbreviations and slang that are meaningful inside the group
 Here are a few useful resources for teasing out meaning from initialisms, acronyms and abbreviations:
 
 * Urban Dictionary (<http://www.urbandictionary.com>)
-* Webster's Online Dictionary (<http://www.websters-online-dictionary.org/>)
+* Webster's Online Dictionary (<http://www.merriam-webster.com/>)
 * Acronym Finder (<http://www.acronymfinder.com/>)
 * A to Z word finder (<http://www.a2zwordfinder.com/>)
 

--- a/pages/mentor/16-upstream_integration.md
+++ b/pages/mentor/16-upstream_integration.md
@@ -49,7 +49,7 @@ Questions a patch reviewer might ask include:
 * Does it follow a relevant specification, RFC or the community-agreed behavior?
 * Are there corner cases or failure situations the author has failed to consider?
 * Does the patch slow down simple tests or other features?
-* Does it follow the project coding guidelines? For an example, see <http://developer.postgresql.org/pgdocs/postgres/source.html>
+* Does it follow the project coding guidelines? For an example, see <http://postgresql.org/docs/current/source.html>
 * Will it work on all supported operating system and hardware platforms?
 * Are the comments sufficient and accurate? Are there any comments at all?
 * Does it produce compiler warnings?

--- a/pages/student/10-open_source_culture.md
+++ b/pages/student/10-open_source_culture.md
@@ -39,7 +39,7 @@ People come up with abbreviations and slang that are meaningful inside the group
 Here are a few useful resources for teasing out meaning from initialisms, acronyms and abbreviations:
 
 * Urban Dictionary (<http://www.urbandictionary.com>)
-* Webster's Online Dictionary (<http://www.websters-online-dictionary.org/>)
+* Webster's Online Dictionary (<http://www.merriam-webster.com/>)
 * The Jargon File (<http://www.catb.org/jargon/html/>)
 * Acronym Finder (<http://www.acronymfinder.com/>)
 * A to Z word finder (<http://www.a2zwordfinder.com/>)


### PR DESCRIPTION
Replaced deprecated external links Webster's dictionary and PostgreSQL developer docs with current, working references.

Old references - http://www.websters-online-dictionary.org/ and http://developer.postgresql.org/pgdocs/postgres/source.html

New references - http://www.merriam-webster.com/ and http://postgresql.org/docs/current/source.html